### PR TITLE
[CC-6258] php5 backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 This file contains highlights of what changes on each version of the [Phing-Smartling](https://github.com/aquafadas-com/phing-smartling) package.
 
+## Version 1.1.0
+- Made the code compatible with PHP 5.5
+
 ## Version 1.0.0
 - First stable release.
 - Updated the package dependencies.

--- a/lib/API.php
+++ b/lib/API.php
@@ -4,14 +4,14 @@
  */
 namespace phing\smartling;
 
-use Smartling\AuthApi\{AuthTokenProvider};
-use Smartling\File\{FileApi};
+use Smartling\AuthApi\AuthTokenProvider;
+use Smartling\File\FileApi;
 
 /**
  * Provides common properties and methods for the [Phing](https://www.phing.info) tasks related to the [Smartling](https://www.smartling.com) service.
  */
-trait API {
-
+trait API
+{
   /**
    * @var string The project identifier.
    */
@@ -31,7 +31,7 @@ trait API {
    * Gets the project identifier.
    * @return string $value The current project identifier.
    */
-  public function getProjectId(): string {
+  public function getProjectId() {
     return $this->projectId;
   }
 
@@ -39,7 +39,7 @@ trait API {
    * Gets the user identifier.
    * @return string The current user identifier.
    */
-  public function getUserId(): string {
+  public function getUserId() {
     return $this->userId;
   }
 
@@ -47,7 +47,7 @@ trait API {
    * Gets the user secret.
    * @return string The current user secret.
    */
-  public function getUserSecret(): string {
+  public function getUserSecret() {
     return $this->userSecret;
   }
 
@@ -55,7 +55,7 @@ trait API {
    * Sets the project identifier.
    * @param string $value The new project identifier.
    */
-  public function setProjectId(string $value) {
+  public function setProjectId($value) {
     $this->projectId = $value;
   }
 
@@ -63,7 +63,7 @@ trait API {
    * Sets the user identifier.
    * @param string $value The new user identifier.
    */
-  public function setUserId(string $value) {
+  public function setUserId($value) {
     $this->userId = $value;
   }
 
@@ -71,7 +71,7 @@ trait API {
    * Sets the user secret.
    * @param string $value The new user secret.
    */
-  public function setUserSecret(string $value) {
+  public function setUserSecret($value) {
     $this->userSecret = $value;
   }
 
@@ -79,7 +79,7 @@ trait API {
    * Creates an authentication token provider.
    * @return AuthTokenProvider The newly created instance.
    */
-  protected function createAuthTokenProvider(): AuthTokenProvider {
+  protected function createAuthTokenProvider() {
     return AuthTokenProvider::create($this->getUserId(), $this->getUserSecret());
   }
 
@@ -87,7 +87,7 @@ trait API {
    * Creates a File API provider.
    * @return FileApi The newly created instance.
    */
-  protected function createFileAPI(): FileApi {
+  protected function createFileAPI() {
     return FileApi::create($this->createAuthTokenProvider(), $this->getProjectId());
   }
 }

--- a/lib/Enum.php
+++ b/lib/Enum.php
@@ -7,8 +7,8 @@ namespace phing\smartling;
 /**
  * Provides static methods for enumerations.
  */
-trait Enum {
-
+trait Enum
+{
   /**
    * Private constructor: prohibit the class instantiation.
    */
@@ -19,7 +19,7 @@ trait Enum {
    * @param mixed $value The value of a constant in this enumeration.
    * @return bool `true` if a constant in this enumeration has the specified value, otherwise `false`.
    */
-  public static function isDefined($value): bool {
+  public static function isDefined($value) {
     return in_array($value, static::getValues());
   }
 
@@ -27,9 +27,11 @@ trait Enum {
    * Retrieves an array of the names and values of the constants in this enumeration.
    * @return array An array that contains the names and values of the constants in this enumeration.
    */
-  public static function getConstants(): array {
+  public static function getConstants() {
     static $constants;
-    if(!isset($constants)) $constants = (new \ReflectionClass(get_called_class()))->getConstants();
+    if(!isset($constants)){
+        $constants = (new \ReflectionClass(get_called_class()))->getConstants();
+    }
     return $constants;
   }
 
@@ -38,7 +40,7 @@ trait Enum {
    * @param mixed $value The value of a constant in this enumeration.
    * @return string A string containing the name of the enumerated constant that has the specified value, or an empty string if no such constant is found.
    */
-  public static function getName($value): string {
+  public static function getName($value) {
     $index = array_search($value, static::getValues());
     return is_int($index) ? static::getNames()[$index] : '';
   }
@@ -47,7 +49,7 @@ trait Enum {
    * Retrieves an array of the names of the constants in this enumeration.
    * @return string[] An array that contains the names of the constants in this enumeration.
    */
-  public static function getNames(): array {
+  public static function getNames() {
     return array_keys(static::getConstants());
   }
 
@@ -55,7 +57,7 @@ trait Enum {
    * Retrieves an array of the values of the constants in this enumeration.
    * @return array An array that contains the values of the constants in this enumeration.
    */
-  public static function getValues(): array {
+  public static function getValues() {
     return array_values(static::getConstants());
   }
 }

--- a/lib/Locale.php
+++ b/lib/Locale.php
@@ -7,8 +7,8 @@ namespace phing\smartling;
 /**
  * Provides static methods for locales.
  */
-class Locale {
-
+class Locale
+{
   /**
    * @var array Provides the mapping between neutral locales and default specific locales.
    */
@@ -36,25 +36,28 @@ class Locale {
     'zh' => 'zh-CN'
   ];
 
-  /**
-   * Private constructor: prohibit the class instantiation.
-   */
-  private function __construct() {}
+    /**
+     * Private constructor: prohibit the class instantiation.
+     */
+    private function __construct() {}
 
-  /**
-   * Returns an array providing the mapping between neutral locales and default specific locales.
-   * @return array The mapping between neutral locales and default specific locales.
-   */
-  public static function getLocales(): array {
-    return static::$locales;
-  }
+    /**
+     * Returns an array providing the mapping between neutral locales and default specific locales.
+     * @return array The mapping between neutral locales and default specific locales.
+     */
+    public static function getLocales()
+    {
+        return static::$locales;
+    }
 
-  /**
-   * Returns the default specific locale corresponding to the specified neutral locale.
-   * @param string $neutralLocale A neutral locale.
-   * @return string The default specific locale corresponding to the specified neutral locale, or the neutral locale if no specific locale matches.
-   */
-  public static function getSpecificLocale(string $neutralLocale): string {
-    return static::getLocales()[$neutralLocale] ?? $neutralLocale;
-  }
+    /**
+     * Returns the default specific locale corresponding to the specified neutral locale.
+     * @param string $neutralLocale A neutral locale.
+     * @return string The default specific locale corresponding to the specified neutral locale, or the neutral locale if no specific locale matches.
+     */
+    public static function getSpecificLocale($neutralLocale)
+    {
+        $locales = static::getLocales();
+        return isset($locales[ $neutralLocale ]) ? $locales[ $neutralLocale ] : $neutralLocale;
+    }
 }

--- a/lib/RetrievalType.php
+++ b/lib/RetrievalType.php
@@ -3,14 +3,14 @@
  * Implementation of the `phing\smartling\RetrievalType` enumeration.
  */
 namespace phing\smartling;
-use Smartling\File\Params\{DownloadFileParameters};
+use Smartling\File\Params\DownloadFileParameters;
 
 /**
  * Defines the retrieval type of a file to be downloaded.
  */
-final class RetrievalType {
+final class RetrievalType
+{
   use Enum;
-
   /**
    * @var string Returns a modified version of the original file with strings wrapped in a specific set of Unicode symbols that can later be recognized and matched by the Chrome Context Capture Extension.
    */

--- a/lib/tasks/DownloadTask.php
+++ b/lib/tasks/DownloadTask.php
@@ -43,7 +43,7 @@ class DownloadTask extends FileTask
      * Gets a value indicating whether to return the original string or an empty string when no translation is available.
      * @return bool `true` to return the original string when no translation is available, otherwise `false`.
      */
-    public function hasIncludeOriginalStrings()
+    public function getIncludeOriginalStrings()
     {
         $params = $this->params->exportToArray();
 

--- a/lib/tasks/DownloadTask.php
+++ b/lib/tasks/DownloadTask.php
@@ -2,139 +2,163 @@
 /**
  * Implementation of the `phing\smartling\tasks\DownloadTask` class.
  */
+
 namespace phing\smartling\tasks;
 
-use phing\smartling\{Locale, RetrievalType};
-use Smartling\Exceptions\{SmartlingApiException};
-use Smartling\File\Params\{DownloadFileParameters};
+use phing\smartling\Locale;
+use phing\smartling\RetrievalType;
+use Smartling\Exceptions\SmartlingApiException;
+use Smartling\File\Params\DownloadFileParameters;
 
 /**
  * Downloads the message translations from the [Smartling](https://www.smartling.com) server.
  */
-class DownloadTask extends FileTask {
+class DownloadTask extends FileTask
+{
+    /**
+     * @var string The pattern indicating the target path of the downloaded files.
+     */
+    private $filePattern = '';
 
-  /**
-   * @var string The pattern indicating the target path of the downloaded files.
-   */
-  private $filePattern = '';
+    /**
+     * @var array The locales to be downloaded.
+     */
+    private $locales = [];
 
-  /**
-   * @var array The locales to be downloaded.
-   */
-  private $locales = [];
+    /**
+     * @var DownloadFileParameters The download parameters.
+     */
+    private $params;
 
-  /**
-   * @var DownloadFileParameters The download parameters.
-   */
-  private $params;
-
-  /**
-   * Gets the pattern indicating the target path of the downloaded files.
-   * @return string The target path of the downloaded files (e.g. `"path/to/i18n/{{locale}}.json"`).
-   */
-  public function getFilePattern(): string {
-    return $this->filePattern;
-  }
-
-  /**
-   * Gets a value indicating whether to return the original string or an empty string when no translation is available.
-   * @return bool `true` to return the original string when no translation is available, otherwise `false`.
-   */
-  public function getIncludeOriginalStrings(): bool {
-    $params = $this->params->exportToArray();
-    return isset($params['includeOriginalStrings']) && $params['includeOriginalStrings'] == 'true';
-  }
-
-  /**
-   * Gets the list of locales to be downloaded.
-   * @return array The locales to download.
-   */
-  public function getLocales(): array {
-    return $this->locales;
-  }
-
-  /**
-   * Gets the desired format for the download.
-   * @return string The current desired format for the download.
-   */
-  public function getRetrievalType(): string {
-    return $this->params->exportToArray()['retrievalType'] ?? RetrievalType::PUBLISHED;
-  }
-
-  /**
-   * Initializes the instance.
-   */
-  public function init() {
-    parent::init();
-    $this->params = new DownloadFileParameters();
-  }
-
-  /**
-   * The task entry point.
-   * @throws \BuildException The requirements are not met, or an error occurred during the processing.
-   */
-  public function main() {
-    parent::main();
-
-    $filePattern = $this->getFilePattern();
-    if(!mb_strlen($filePattern)) throw new \BuildException('You must provide the "filePattern" attribute.');
-
-    $locales = $this->getLocales();
-    if(!$locales) throw new \BuildException('You must specify at least one locale in the "locales" attribute.');
-
-    try {
-      $fileAPI = $this->createFileAPI();
-      $fileURI = $this->getFileURI();
-
-      foreach ($locales as $locale) {
-        $path = str_replace('{{locale}}', $locale, $filePattern);
-
-        $output = dirname($path);
-        if(!is_dir($output) && !mkdir($output, 0755, true)) throw new \BuildException("Unable to create the output folder: $output");
-
-        if(!file_put_contents($path, $fileAPI->downloadFile($fileURI, Locale::getSpecificLocale($locale), $this->params)))
-          throw new \BuildException("Unable to save the downloaded file: $path");
-      }
+    /**
+     * Gets the pattern indicating the target path of the downloaded files.
+     * @return string The target path of the downloaded files (e.g. `"path/to/i18n/{{locale}}.json"`).
+     */
+    public function getFilePattern()
+    {
+        return $this->filePattern;
     }
 
-    catch(SmartlingApiException $e) {
-      throw new \BuildException($e);
+    /**
+     * Gets a value indicating whether to return the original string or an empty string when no translation is available.
+     * @return bool `true` to return the original string when no translation is available, otherwise `false`.
+     */
+    public function getIncludeOriginalStrings()
+    {
+        $params = $this->params->exportToArray();
+
+        return isset($params[ 'includeOriginalStrings' ]) && $params[ 'includeOriginalStrings' ] == 'true';
     }
-  }
 
-  /**
-   * Sets the pattern indicating the target path of the downloaded files.
-   * @param string $value The new target path of the downloaded files (e.g. `"path/to/i18n/{{locale}}.json"`).
-   */
-  public function setFilePattern(string $value) {
-    $this->filePattern = $value;
-  }
+    /**
+     * Gets the list of locales to be downloaded.
+     * @return array The locales to download.
+     */
+    public function getLocales()
+    {
+        return $this->locales;
+    }
 
-  /**
-   * Sets a value indicating whether to return the original string or an empty string when no translation is available.
-   * @param bool $value `true` to return the original string when no translation is available, otherwise `false`.
-   */
-  public function setIncludeOriginalStrings(bool $value) {
-    $this->params->setIncludeOriginalStrings($value ? 'true' : 'false');
-  }
+    /**
+     * Gets the desired format for the download.
+     * @return string The current desired format for the download.
+     */
+    public function getRetrievalType()
+    {
+        $paramArray = $this->params->exportToArray();
+        return isset($paramArray[ 'retrievalType' ]) ? $paramArray[ 'retrievalType' ] : RetrievalType::PUBLISHED;
+    }
 
-  /**
-   * Sets the list of locales to be downloaded.
-   * @param string $values The locales to download.
-   */
-  public function setLocales(string $values) {
-    $this->locales = array_filter(array_map('trim', explode(',', $values)), function($locale) {
-      return mb_strlen($locale);
-    });
-  }
+    /**
+     * Initializes the instance.
+     */
+    public function init()
+    {
+        parent::init();
+        $this->params = new DownloadFileParameters();
+    }
 
-  /**
-   * Sets the desired format for the download.
-   * @param string $value The new desired format for the download.
-   * @throws \BuildException The specified value is invalid.
-   */
-  public function setRetrievalType(string $value) {
-    try { $this->params->setRetrievalType($value); }
-    catch(SmartlingApiException $e) { throw new \BuildException($e); }
-  }
+    /**
+     * The task entry point.
+     * @throws \BuildException The requirements are not met, or an error occurred during the processing.
+     */
+    public function main()
+    {
+        parent::main();
+
+        $filePattern = $this->getFilePattern();
+        if (! mb_strlen($filePattern)) {
+            throw new \BuildException('You must provide the "filePattern" attribute.');
+        }
+
+        $locales = $this->getLocales();
+        if (! $locales) {
+            throw new \BuildException('You must specify at least one locale in the "locales" attribute.');
+        }
+
+        try {
+            $fileAPI = $this->createFileAPI();
+            $fileURI = $this->getFileURI();
+
+            foreach ($locales as $locale) {
+                $path = str_replace('{{locale}}', $locale, $filePattern);
+
+                $output = dirname($path);
+                if (! is_dir($output) && ! mkdir($output, 0755, true)) {
+                    throw new \BuildException("Unable to create the output folder: $output");
+                }
+
+                if (! file_put_contents($path,
+                    $fileAPI->downloadFile($fileURI, Locale::getSpecificLocale($locale), $this->params))
+                ) {
+                    throw new \BuildException("Unable to save the downloaded file: $path");
+                }
+            }
+        } catch (SmartlingApiException $e) {
+            throw new \BuildException($e);
+        }
+    }
+
+    /**
+     * Sets the pattern indicating the target path of the downloaded files.
+     * @param string $value The new target path of the downloaded files (e.g. `"path/to/i18n/{{locale}}.json"`).
+     */
+    public function setFilePattern($value)
+    {
+        $this->filePattern = $value;
+    }
+
+    /**
+     * Sets a value indicating whether to return the original string or an empty string when no translation is available.
+     * @param bool $value `true` to return the original string when no translation is available, otherwise `false`.
+     */
+    public function setIncludeOriginalStrings($value)
+    {
+        $this->params->setIncludeOriginalStrings($value ? 'true' : 'false');
+    }
+
+    /**
+     * Sets the list of locales to be downloaded.
+     * @param string $values The locales to download.
+     */
+    public function setLocales($values)
+    {
+        $this->locales = array_filter(array_map('trim', explode(',', $values)), function ($locale) {
+            return mb_strlen($locale);
+        });
+    }
+
+    /**
+     * Sets the desired format for the download.
+     * @param string $value The new desired format for the download.
+     * @throws \BuildException The specified value is invalid.
+     */
+    public function setRetrievalType($value)
+    {
+        try {
+            $this->params->setRetrievalType($value);
+        } catch (SmartlingApiException $e) {
+            throw new \BuildException($e);
+        }
+    }
 }

--- a/lib/tasks/DownloadTask.php
+++ b/lib/tasks/DownloadTask.php
@@ -43,7 +43,7 @@ class DownloadTask extends FileTask
      * Gets a value indicating whether to return the original string or an empty string when no translation is available.
      * @return bool `true` to return the original string when no translation is available, otherwise `false`.
      */
-    public function getIncludeOriginalStrings()
+    public function hasIncludeOriginalStrings()
     {
         $params = $this->params->exportToArray();
 

--- a/lib/tasks/FileTask.php
+++ b/lib/tasks/FileTask.php
@@ -2,81 +2,97 @@
 /**
  * Implementation of the `phing\smartling\tasks\FileTask` class.
  */
+
 namespace phing\smartling\tasks;
-use phing\smartling\{API, FileType};
+
+use phing\smartling\API;
+use phing\smartling\FileType;
 
 /**
  * Provides the base implementation for file-based tasks.
  */
-abstract class FileTask extends \Task {
-  use API;
+abstract class FileTask extends \Task
+{
+    use API;
 
-  /**
-   * @var string The file URI.
-   */
-  private $fileURI = '';
+    /**
+     * @var string The file URI.
+     */
+    private $fileURI = '';
 
-  /**
-   * Gets a value that uniquely identifies the file.
-   * @return string The current file URI.
-   */
-  public function getFileURI(): string {
-    return $this->fileURI;
-  }
-
-  /**
-   * The task entry point.
-   * @throws \BuildException The requirements are not met.
-   */
-  public function main() {
-    if(!mb_strlen($this->getFileURI())) throw new \BuildException('Your must provide the "fileURI" attribute.');
-    if(!mb_strlen($this->getProjectId())) throw new \BuildException('Your must provide the "projectId" attribute.');
-    if(!mb_strlen($this->getUserId())) throw new \BuildException('Your must provide the "userId" attribute.');
-    if(!mb_strlen($this->getUserSecret())) throw new \BuildException('Your must provide "userSecret" attribute.');
-  }
-
-  /**
-   * Sets a value that uniquely identifies the file.
-   * @param string $value The new file URI.
-   */
-  public function setFileURI(string $value) {
-    $this->fileURI = $value;
-  }
-
-  /**
-   * Returns the file type corresponding to the specified file URI.
-   * @param string $fileURI The file URI.
-   * @return string The file type corresponding to the specified file URI, or an empty string if the type is unknown.
-   */
-  protected static function getFileTypeFromURI(string $fileURI): string {
-    $extension = mb_strtolower(pathinfo($fileURI, PATHINFO_EXTENSION));
-    switch($extension) {
-      case FileType::CSV:
-      case FileType::HTML:
-      case FileType::INDESIGN:
-      case FileType::JSON:
-      case FileType::OPEN_XML:
-      case FileType::RESX:
-      case FileType::YAML:
-        return $extension;
-
-      case 'properties':
-        return FileType::JAVA_PROPERTIES;
-
-      case 'ts':
-        return FileType::QT_LINGUIST;
-
-      case 'txt':
-        return FileType::PLAIN_TEXT;
-
-      case 'xlf':
-        return FileType::XLIFF;
-
-      case 'yml':
-        return FileType::YAML;
-
-      default:
-        return '';
+    /**
+     * Gets a value that uniquely identifies the file.
+     * @return string The current file URI.
+     */
+    public function getFileURI()
+    {
+        return $this->fileURI;
     }
-  }
+
+    /**
+     * The task entry point.
+     * @throws \BuildException The requirements are not met.
+     */
+    public function main()
+    {
+        if (! mb_strlen($this->getFileURI())) {
+            throw new \BuildException('Your must provide the "fileURI" attribute.');
+        }
+        if (! mb_strlen($this->getProjectId())) {
+            throw new \BuildException('Your must provide the "projectId" attribute.');
+        }
+        if (! mb_strlen($this->getUserId())) {
+            throw new \BuildException('Your must provide the "userId" attribute.');
+        }
+        if (! mb_strlen($this->getUserSecret())) {
+            throw new \BuildException('Your must provide "userSecret" attribute.');
+        }
+    }
+
+    /**
+     * Sets a value that uniquely identifies the file.
+     * @param string $value The new file URI.
+     */
+    public function setFileURI($value)
+    {
+        $this->fileURI = $value;
+    }
+
+    /**
+     * Returns the file type corresponding to the specified file URI.
+     * @param string $fileURI The file URI.
+     * @return string The file type corresponding to the specified file URI, or an empty string if the type is unknown.
+     */
+    protected static function getFileTypeFromURI($fileURI)
+    {
+        $extension = mb_strtolower(pathinfo($fileURI, PATHINFO_EXTENSION));
+        switch ($extension) {
+            case FileType::CSV:
+            case FileType::HTML:
+            case FileType::INDESIGN:
+            case FileType::JSON:
+            case FileType::OPEN_XML:
+            case FileType::RESX:
+            case FileType::YAML:
+                return $extension;
+
+            case 'properties':
+                return FileType::JAVA_PROPERTIES;
+
+            case 'ts':
+                return FileType::QT_LINGUIST;
+
+            case 'txt':
+                return FileType::PLAIN_TEXT;
+
+            case 'xlf':
+                return FileType::XLIFF;
+
+            case 'yml':
+                return FileType::YAML;
+
+            default:
+                return '';
+        }
+    }
 }

--- a/lib/tasks/UploadTask.php
+++ b/lib/tasks/UploadTask.php
@@ -33,7 +33,7 @@ class UploadTask extends FileTask
      * Gets a value indicating whether content in the file is authorized (available for translation) in all locales.
      * @return bool `true` to authorize the file content in all locales, otherwise `false`.
      */
-    public function getAuthorize()
+    public function isAuthorized()
     {
         $params = $this->params->exportToArray();
         return isset($params[ 'authorize' ]) && $params[ 'authorize' ] == 'true';

--- a/lib/tasks/UploadTask.php
+++ b/lib/tasks/UploadTask.php
@@ -2,122 +2,145 @@
 /**
  * Implementation of the `phing\smartling\tasks\UploadTask` class.
  */
+
 namespace phing\smartling\tasks;
 
-use phing\smartling\{FileType};
-use Smartling\Exceptions\{SmartlingApiException};
-use Smartling\File\Params\{UploadFileParameters};
+use phing\smartling\FileType;
+use Smartling\Exceptions\SmartlingApiException;
+use Smartling\File\Params\UploadFileParameters;
 
 /**
  * Uploads the message translations to the [Smartling](https://www.smartling.com) server.
  */
-class UploadTask extends FileTask {
+class UploadTask extends FileTask
+{
+    /**
+     * @var \PhingFile The path to the message source.
+     */
+    private $file;
 
-  /**
-   * @var \PhingFile The path to the message source.
-   */
-  private $file;
+    /**
+     * @var string The file type.
+     */
+    private $fileType = '';
 
-  /**
-   * @var string The file type.
-   */
-  private $fileType = '';
+    /**
+     * @var UploadFileParameters The upload parameters.
+     */
+    private $params;
 
-  /**
-   * @var UploadFileParameters The upload parameters.
-   */
-  private $params;
+    /**
+     * Gets a value indicating whether content in the file is authorized (available for translation) in all locales.
+     * @return bool `true` to authorize the file content in all locales, otherwise `false`.
+     */
+    public function getAuthorize()
+    {
+        $params = $this->params->exportToArray();
+        return isset($params[ 'authorize' ]) && $params[ 'authorize' ] == 'true';
+    }
 
-  /**
-   * Gets a value indicating whether content in the file is authorized (available for translation) in all locales.
-   * @return bool `true` to authorize the file content in all locales, otherwise `false`.
-   */
-  public function getAuthorize(): bool {
-    $params = $this->params->exportToArray();
-    return isset($params['authorize']) && $params['authorize'] == 'true';
-  }
+    /**
+     * Gets the URL of the callback called when the file is 100% published for a locale.
+     * @return string The callback URL.
+     */
+    public function getCallbackUrl()
+    {
+        $paramArray = $this->params->exportToArray();
+        return isset($paramArray[ 'callbackUrl' ]) ? $paramArray[ 'callbackUrl' ] : '';
+    }
 
-  /**
-   * Gets the URL of the callback called when the file is 100% published for a locale.
-   * @return string The callback URL.
-   */
-  public function getCallbackUrl(): string {
-    return $this->params->exportToArray()['callbackUrl'] ?? '';
-  }
+    /**
+     * Gets the path to the message source.
+     * @return \PhingFile The path to the message source.
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
 
-  /**
-   * Gets the path to the message source.
-   * @return \PhingFile The path to the message source.
-   */
-  public function getFile(): \PhingFile {
-    return $this->file;
-  }
+    /**
+     * Gets the file type.
+     * @return string The current file type.
+     */
+    public function getFileType()
+    {
+        return $this->fileType;
+    }
 
-  /**
-   * Gets the file type.
-   * @return string The current file type.
-   */
-  public function getFileType(): string {
-    return $this->fileType;
-  }
+    /**
+     * Initializes the instance.
+     */
+    public function init()
+    {
+        parent::init();
+        $this->params = new UploadFileParameters();
+    }
 
-  /**
-   * Initializes the instance.
-   */
-  public function init() {
-    parent::init();
-    $this->params = new UploadFileParameters();
-  }
+    /**
+     * The task entry point.
+     * @throws \BuildException The requirements are not met.
+     */
+    public function main()
+    {
+        parent::main();
 
-  /**
-   * The task entry point.
-   * @throws \BuildException The requirements are not met.
-   */
-  public function main() {
-    parent::main();
+        $file = $this->getFile();
+        if (! $file) {
+            throw new \BuildException('You must provide the "file" attribute.');
+        }
+        if (! $file->isFile()) {
+            throw new \BuildException('Unable to find the message source specified by the "file" attribute.');
+        }
 
-    $file = $this->getFile();
-    if(!$file) throw new \BuildException('You must provide the "file" attribute.');
-    if(!$file->isFile()) throw new \BuildException('Unable to find the message source specified by the "file" attribute.');
+        $fileType = $this->getFileType();
+        $fileURI  = $this->getFileURI();
+        if (! mb_strlen($fileType)) {
+            $fileType = static::getFileTypeFromURI($fileURI);
+        }
+        if (! FileType::isDefined($fileType)) {
+            throw new \BuildException('Invalid "fileType" attribute.');
+        }
 
-    $fileType = $this->getFileType();
-    $fileURI = $this->getFileURI();
-    if(!mb_strlen($fileType)) $fileType = static::getFileTypeFromURI($fileURI);
-    if(!FileType::isDefined($fileType)) throw new \BuildException('Invalid "fileType" attribute.');
+        try {
+            $this->createFileAPI()->uploadFile($file->getAbsolutePath(), $fileURI, $fileType, $this->params);
+        } catch (SmartlingApiException $e) {
+            throw new \BuildException($e);
+        }
+    }
 
-    try { $this->createFileAPI()->uploadFile($file->getAbsolutePath(), $fileURI, $fileType, $this->params); }
-    catch(SmartlingApiException $e) { throw new \BuildException($e); }
-  }
+    /**
+     * Sets a value indicating whether content in the file is authorized (available for translation) in all locales.
+     * @param bool $value `true` to authorize the file content in all locales, otherwise `false`.
+     */
+    public function setAuthorize($value)
+    {
+        $this->params->setAuthorized($value ? 'true' : 'false');
+    }
 
-  /**
-   * Sets a value indicating whether content in the file is authorized (available for translation) in all locales.
-   * @param bool $value `true` to authorize the file content in all locales, otherwise `false`.
-   */
-  public function setAuthorize(bool $value) {
-    $this->params->setAuthorized($value ? 'true' : 'false');
-  }
+    /**
+     * Sets the URL of the callback called when the file is 100% published for a locale.
+     * @param string $value The new callback URL.
+     */
+    public function setCallbackUrl($value)
+    {
+        $this->params->setCallbackUrl($value);
+    }
 
-  /**
-   * Sets the URL of the callback called when the file is 100% published for a locale.
-   * @param string $value The new callback URL.
-   */
-  public function setCallbackUrl(string $value) {
-    $this->params->setCallbackUrl($value);
-  }
+    /**
+     * Sets the path to the message source.
+     * @param \PhingFile $value The new path of the message source.
+     */
+    public function setFile(\PhingFile $value)
+    {
+        $this->file = $value;
+    }
 
-  /**
-   * Sets the path to the message source.
-   * @param \PhingFile $value The new path of the message source.
-   */
-  public function setFile(\PhingFile $value) {
-    $this->file = $value;
-  }
-
-  /**
-   * Sets the file type.
-   * @param string $value The new file type.
-   */
-  public function setFileType(string $value) {
-    $this->fileType = $value;
-  }
+    /**
+     * Sets the file type.
+     * @param string $value The new file type.
+     */
+    public function setFileType($value)
+    {
+        $this->fileType = $value;
+    }
 }

--- a/lib/tasks/UploadTask.php
+++ b/lib/tasks/UploadTask.php
@@ -33,7 +33,7 @@ class UploadTask extends FileTask
      * Gets a value indicating whether content in the file is authorized (available for translation) in all locales.
      * @return bool `true` to authorize the file content in all locales, otherwise `false`.
      */
-    public function isAuthorized()
+    public function getAuthorize()
     {
         $params = $this->params->exportToArray();
         return isset($params[ 'authorize' ]) && $params[ 'authorize' ] == 'true';

--- a/test/EnumTest.php
+++ b/test/EnumTest.php
@@ -3,7 +3,7 @@
  * Implementation of the `phing\smartling\test\EnumTest` class.
  */
 namespace phing\smartling\test;
-use phing\smartling\{Enum};
+use phing\smartling\Enum;
 
 /**
  * A sample enumeration.

--- a/test/LocaleTest.php
+++ b/test/LocaleTest.php
@@ -3,7 +3,7 @@
  * Implementation of the `phing\smartling\test\LocaleTest` class.
  */
 namespace phing\smartling\test;
-use phing\smartling\{Locale};
+use phing\smartling\Locale;
 
 /**
  * Tests the features of the `phing\smartling\Locale` class.

--- a/test/tasks/FileTaskTest.php
+++ b/test/tasks/FileTaskTest.php
@@ -4,8 +4,8 @@
  */
 namespace phing\smartling\test\tasks;
 
-use phing\smartling\{FileType};
-use phing\smartling\tasks\{FileTask};
+use phing\smartling\FileType;
+use phing\smartling\tasks\FileTask;
 
 /**
  * A sample file task.
@@ -17,7 +17,7 @@ class SampleFileTask extends FileTask {
    * @param string $fileURI The file URI.
    * @return string The file type corresponding to the specified file URI, or an empty string if the type is unknown.
    */
-  public static function getFileTypeFromURI(string $fileURI): string {
+  public static function getFileTypeFromURI($fileURI) {
     return parent::getFileTypeFromURI($fileURI);
   }
 }


### PR DESCRIPTION
suppressions de typages, d'usages groupés de namespaces, d'opérateurs '??'... syntaxes spécifiques à php7 